### PR TITLE
Do not allow blank issues by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: WalletConnect Discord
+    url: https://discord.gg/jhxMvxP
+    about: If you have questions related to the registry, ask them there.


### PR DESCRIPTION
While this won't address the issue people not filling in information, at least it should deter from having clearly blank issues.