### PR TITLE
Fix D'CENT wallet universal link

### DIFF
--- a/public/data/wallets.json
+++ b/public/data/wallets.json
@@ -857,7 +857,7 @@
     },
     "mobile": {
       "native": "dcent:",
-      "universal": "https://link.dcentwallet.com/"
+      "universal": "https://link.dcentwallet.com"
     },
     "desktop": {
       "native": "",


### PR DESCRIPTION
Just remove the last character '/' from the universal link URL