### PR TITLE
move CeloTerminal from dapps to wallet

### DIFF
--- a/public/data/dapps.json
+++ b/public/data/dapps.json
@@ -4620,41 +4620,6 @@
       }
     }
   },
-  "8f8506b7f191a8ab95a8295fc8ca147aa152b1358bee4283d6ad2468d97e0ca4": {
-    "id": "8f8506b7f191a8ab95a8295fc8ca147aa152b1358bee4283d6ad2468d97e0ca4",
-    "name": "CeloTerminal",
-    "description": "The one-stop shop for everything Celo",
-    "homepage": "https://celoterminal.com",
-    "chains": [
-      "eip155:42220"
-    ],
-    "versions": [
-      "1"
-    ],
-    "app": {
-      "browser": "https://celoterminal.com",
-      "ios": "",
-      "android": "",
-      "mac": "",
-      "windows": "",
-      "linux": ""
-    },
-    "mobile": {
-      "native": "",
-      "universal": ""
-    },
-    "desktop": {
-      "native": "",
-      "universal": ""
-    },
-    "metadata": {
-      "shortName": "",
-      "colors": {
-        "primary": "",
-        "secondary": ""
-      }
-    }
-  },
   "c56663507f4a19ce710f784f84c3e45ec73fda6dd3abb36ef381400cb3604abf": {
     "id": "c56663507f4a19ce710f784f84c3e45ec73fda6dd3abb36ef381400cb3604abf",
     "name": "U-Swap",

--- a/public/data/wallets.json
+++ b/public/data/wallets.json
@@ -3871,6 +3871,41 @@
       }
     }
   },
+  "8f8506b7f191a8ab95a8295fc8ca147aa152b1358bee4283d6ad2468d97e0ca4": {
+    "id": "8f8506b7f191a8ab95a8295fc8ca147aa152b1358bee4283d6ad2468d97e0ca4",
+    "name": "CeloTerminal",
+    "description": "The one-stop shop for everything Celo",
+    "homepage": "https://celoterminal.com",
+    "chains": [
+      "eip155:42220"
+    ],
+    "versions": [
+      "1"
+    ],
+    "app": {
+      "browser": "https://celoterminal.com",
+      "ios": "",
+      "android": "",
+      "mac": "",
+      "windows": "",
+      "linux": ""
+    },
+    "mobile": {
+      "native": "",
+      "universal": ""
+    },
+    "desktop": {
+      "native": "",
+      "universal": ""
+    },
+    "metadata": {
+      "shortName": "",
+      "colors": {
+        "primary": "",
+        "secondary": ""
+      }
+    }
+  },
   "2c81da3add65899baeac53758a07e652eea46dbb5195b8074772c62a77bbf568": {
     "id": "2c81da3add65899baeac53758a07e652eea46dbb5195b8074772c62a77bbf568",
     "name": "Ambire Wallet",


### PR DESCRIPTION
@pedrouid CeloTerminal was incorrectly added as a DApp instead of a wallet. I am not sure if the IDs still make sense though.